### PR TITLE
feature: Create table on load

### DIFF
--- a/sherpa/main.py
+++ b/sherpa/main.py
@@ -47,7 +47,9 @@ def load(
     file: Path = Argument(..., help="Path to file to load"),
     table: str = Option("", "--table", "-t", help="Name of table to load to"),
     schema: str = Option("public", "--schema", "-s", help="Schema of table to load to"),
-    create_table: bool = Option(False, "--create", "-c", help="Creates a table inferring the schema from the load file")
+    create_table: bool = Option(
+        False, "--create", "-c", help="Creates a table inferring the schema from the load file"
+    ),
 ) -> None:
     """
     Load a file to a PostGIS table

--- a/sherpa/main.py
+++ b/sherpa/main.py
@@ -45,15 +45,16 @@ def list_tables(schema: str = Option("public", "--schema", "-s", help="Schema of
 @app.command()
 def load(
     file: Path = Argument(..., help="Path to file to load"),
-    table: str = Argument(..., help="Name of table to load to"),
+    table: str = Option("", "--table", "-t", help="Name of table to load to"),
     schema: str = Option("public", "--schema", "-s", help="Schema of table to load to"),
+    create_table: bool = Option(False, "--create", "-c", help="Creates a table inferring the schema from the load file")
 ) -> None:
     """
     Load a file to a PostGIS table
     """
     current_config = load_config(CONFIG_FILE)
     client = PgClient(current_config["default"])
-    client.load(file, table, schema)
+    client.load(file, table, schema, create_table)
     client.close()
 
 

--- a/sherpa/pg_client.py
+++ b/sherpa/pg_client.py
@@ -34,7 +34,9 @@ class PgClient:
         try:
             self.conn = connect(**connection_details)
         except DatabaseError:
-            console.print(f"[bold red]Error:[/bold red] Unable to connect to database [bold cyan]{connection_details['dbname']}[/bold cyan]")
+            console.print(
+                f"[bold red]Error:[/bold red] Unable to connect to database [bold cyan]{connection_details['dbname']}[/bold cyan]"
+            )
             exit(1)
 
     def close(self) -> None:
@@ -83,12 +85,16 @@ class PgClient:
             results = cursor.fetchall()
 
         if len(results) == 0:
-            console.print(f"[bold red]Error:[/bold red] unable to get table structure for [bold cyan]{schema}.{table}[/bold cyan]")
+            console.print(
+                f"[bold red]Error:[/bold red] unable to get table structure for [bold cyan]{schema}.{table}[/bold cyan]"
+            )
             exit(1)
 
         return PgTable(name=table, columns=[result for (result,) in results])
 
-    def load(self, file: Path, table: str, schema: str = "public", create_table: bool = False, batch_size: int = 10000) -> None:
+    def load(
+        self, file: Path, table: str, schema: str = "public", create_table: bool = False, batch_size: int = 10000
+    ) -> None:
         if not table and create_table is False:
             console.print("[bold red]Error:[/bold red] you must provide a table name or the --create option")
             exit(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,28 @@
 import pytest
 import toml
 import fiona
+from psycopg2 import connect
 
 from sherpa.pg_client import PgClient
-from tests.utils import truncate_tables
+from tests.utils import truncate_test_table
 
 
 @pytest.fixture
 def pg_client(default_config):
-    yield PgClient(default_config["default"])
-    truncate_tables(default_config["default"])
+    client = PgClient(default_config["default"])
+    yield client
+    client.close()
+    truncate_test_table(default_config["default"])
+
+
+@pytest.fixture
+def pg_connection(default_config):
+    conn = connect(**default_config["default"])
+    yield conn
+    conn.close()
+    # If a SQL transaction is aborted, all subsequent SQL commands will be ignored
+    # so reopening the connection to drop test data is necessary
+    truncate_test_table(default_config["default"])
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,15 @@ import pytest
 import toml
 import fiona
 
+from sherpa.pg_client import PgClient
+from tests.utils import truncate_tables
+
+
+@pytest.fixture
+def pg_client(default_config):
+    yield PgClient(default_config["default"])
+    truncate_tables(default_config["default"])
+
 
 @pytest.fixture
 def default_config():

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,1 +1,0 @@
-TEST_TABLE = "geometry_load_test"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,1 @@
+TEST_TABLE = "geometry_load_test"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,6 +76,29 @@ def test_cmd_load_create_table(runner, geojson_file, pg_connection):
     assert result.exit_code == 0
 
     with pg_connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT 
+                polygon_id, 
+                geometry 
+            FROM public.test_geojson_file
+            """
+        )
+        results = cursor.fetchall()
+
+    assert results == [
+        ('ABC123', '0103000020E61000000100000004000000235F53311F9462407C992842EAA841C0EE9E97E546946240A898391389A941C07FE5F7ECEF93624046B1DCD26AA941C0235F53311F9462407C992842EAA841C0'),
+        ('ABC123', '0103000020E610000001000000040000005673CAED68946240E902A8F3F2A941C0D913138AA39462400C90680245A941C0C5B01E52A7946240D4974AE427AA41C05673CAED68946240E902A8F3F2A941C0'),
+        ('DEF456', '0103000020E61000000100000004000000D1FEAC9EF8946240E2B9ADE3AEA941C09BBA3CE7389562408FF4B3A217A941C09BBA3CE73895624072B0EDA309AA41C0D1FEAC9EF8946240E2B9ADE3AEA941C0'),
+        ('GHI789', '0103000020E6100000010000000400000090F06206CF9462405B83520F2CA741C095511B8B1C956240D81E076F59A741C0A3CFA2D2E3946240A026E9503CA841C090F06206CF9462405B83520F2CA741C0')
+    ]
+
+    with pg_connection.cursor() as cursor:
         cursor.execute("DROP TABLE public.test_geojson_file")
     pg_connection.commit()
 
+
+def test_cmd_load_no_table_input(runner, geojson_file):
+    result = runner.invoke(main.app, ["load", str(geojson_file)])
+    assert result.exit_code == 1
+    assert "Error: you must provide a table name or the --create option" in result.stdout

--- a/tests/test_pg_client.py
+++ b/tests/test_pg_client.py
@@ -1,22 +1,10 @@
 import pytest
 import fiona
-from psycopg2 import connect
 from psycopg2.sql import SQL, Identifier, Composed
 from rich.table import Table
 
 from sherpa.pg_client import PgTable, generate_row_data, generate_sql_insert_row, generate_sql_transforms
 from tests.constants import TEST_TABLE
-from tests.utils import truncate_tables
-
-
-@pytest.fixture
-def pg_connection(default_config):
-    conn = connect(**default_config["default"])
-    yield conn
-    conn.close()
-    # If a SQL transaction is aborted, all subsequent SQL commands will be ignored
-    # so reopening the connection to drop test data is necessary
-    truncate_tables(default_config["default"])
 
 
 @pytest.fixture

--- a/tests/test_pg_client.py
+++ b/tests/test_pg_client.py
@@ -4,16 +4,9 @@ from psycopg2 import connect
 from psycopg2.sql import SQL, Identifier, Composed
 from rich.table import Table
 
-from sherpa.pg_client import PgClient, PgTable, generate_row_data, generate_sql_insert_row, generate_sql_transforms
+from sherpa.pg_client import PgTable, generate_row_data, generate_sql_insert_row, generate_sql_transforms
 from tests.constants import TEST_TABLE
-
-
-def truncate_tables(config):
-    conn = connect(**config)
-    with conn:
-        with conn.cursor() as cursor:
-            cursor.execute(SQL("TRUNCATE TABLE {} CASCADE").format(Identifier(TEST_TABLE)))
-    conn.close()
+from tests.utils import truncate_tables
 
 
 @pytest.fixture
@@ -27,15 +20,8 @@ def pg_connection(default_config):
 
 
 @pytest.fixture
-def pg_client(default_config):
-    yield PgClient(default_config["default"])
-    truncate_tables(default_config["default"])
-
-
-@pytest.fixture
 def pg_table(default_config):
     yield PgTable(TEST_TABLE, ["polygon_id", "geometry"])
-    truncate_tables(default_config["default"])  # Why is this necessary?
 
 
 @pytest.fixture

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+from psycopg2 import connect
+from psycopg2.sql import SQL, Identifier
+
+from tests.constants import TEST_TABLE
+
+
+def truncate_test_table(config):
+    conn = connect(**config)
+    with conn:
+        with conn.cursor() as cursor:
+            cursor.execute(SQL("TRUNCATE TABLE {} CASCADE").format(Identifier(TEST_TABLE)))
+    conn.close()


### PR DESCRIPTION
Adds an option to create a table on load.

* Uses the file name (without suffix) as the table name.
* Creates all columns as TEXT - this should be changed in future to infer the DB data type from the Python data type.

Restructured the load command to have the `file` as the only argument, changing the `table` input to an option with no default. If no table is passed and the `--create` option isn't provided then an error will be propagated to the user.